### PR TITLE
Removing the no quoted keys rule.

### DIFF
--- a/javascript/jscsrc.js
+++ b/javascript/jscsrc.js
@@ -4,7 +4,6 @@
   "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleLineStrings": true,
-  "disallowQuotedKeysInObjects": "allButReserved",
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],


### PR DESCRIPTION
@MikeKlemarewski @stewartyu 

Removing this rule, as I'd like to use the linter for things like Nightwatch etc. Nightwatch specifically uses quoted keys in objects, so this rule will always fail.
