### PR TITLE
Fix unary operators

### DIFF
--- a/javascript/.jscsrc
+++ b/javascript/.jscsrc
@@ -1,7 +1,7 @@
 {
   "disallowEmptyBlocks": true,
   "disallowKeywords": ["with"],
-  "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+  "disallowLeftStickedOperators": ["?", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleLineStrings": true,
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],


### PR DESCRIPTION
JSCS complains when unary operators are used. For example, .slice(-1, 2).

Status: **Opened for visibility**
Reviewers: @tedtate @scalvert 
## Changes
- Don't complain about slice(-1, 2), or var = +num; etc.
