### PR TITLE
Fix confusing comment re: function casing.

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -191,7 +191,7 @@ var computer = {};
 Use camel-case for function names
 
 ````javascript
-// bad: this is our variable name convention
+// bad: underscores shouldn’t be used in identifiers
 function recalculate_item_height() { ... }
  
 // bad: this is our constructor name convention


### PR DESCRIPTION
In the JS readme, there is a confusing comment in the example describing how to name functions – seeming to indicate as an aside that variables should be snake_case, which isn’t right.

Status: **Ready to merge**

Reviewers: @jansepar 
Ticket: Fixes #1 
Linked PRs: N/A
## Changes
- Changes the comment to reflect what is wrong with the bad example in question.
