### PR TITLE
Fix whitespace not conforming to code style in some examples.

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -33,17 +33,17 @@ Don't use magic numbers
 
 ````javascript
 // bad: what was 3 again? Text node? Comment?
-if(el.nodeType === 3) { ... } 
+if (el.nodeType === 3) { ... }
  
 // bad: The reader doesn't know why we chose 7, and if we change 7 with 8, we'll have to carefully search and replace all occurrences
-if($('.blah').length === 7) { ... }
+if ($('.blah').length === 7) { ... }
  
 // good
  
-if(el.nodeType === Node.TEXT_NODE) { ... }
+if (el.nodeType === Node.TEXT_NODE) { ... }
  
 // good
-if($('.blah').length === defaultRoomCount) { ... }
+if ($('.blah').length === defaultRoomCount) { ... }
 ````
 
 Declare variables with var


### PR DESCRIPTION
In the examples about not using magic numbers, the if statements don’t (but should) conform to the code style advocated further down in the guide.

Status: **Ready to merge**

Reviewers: @jansepar 
Ticket: N/A
Linked PRs: N/A
## Changes
- In examples not demonstrating bad style, fix missing space between `if` and opening parens.
