### PR TITLE
Fixed: the URL link to the style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ jscs: {
 }
 ```
 ## CSS
-Our Client Services team's [CSS Style Guide](/css-handbook/Readme.md). Written with a lot of tender care by @kpeatt and @jeffkamo.
+Our Client Services team's [CSS Style Guide](/css/Readme.md). Written with a lot of tender care by @kpeatt and @jeffkamo.


### PR DESCRIPTION
Was: https://github.com/mobify/mobify-code-style/blob/master/css-handbook/Readme.md
Now: https://github.com/mobify/mobify-code-style/blob/master/css/Readme.md

@jamesbull
