### PR TITLE
Naming convention additions

### DIFF
--- a/css/Readme.md
+++ b/css/Readme.md
@@ -4,7 +4,7 @@ We follow a mixture of various methodologies include, but not limited to: SMACSS
 
 # Tools & Frameworks
 
-* [Sass](http://sass-lang.com/)s
+* [Sass](http://sass-lang.com/)
 * [Autoprefixer](https://github.com/ai/autoprefixer)
 * [Vellum](https://github.com/mobify/vellum)
 * [Spline](https://github.com/mobify/spline)


### PR DESCRIPTION
Status: **Opened for visibility**
Reviewers: @kpeatt @ry5n 
JIRA: n/a
## Changes
- Added a `c-` component example under Class Naming Conventions
- Added a few notes about avoiding `js-` classes in our stylesheets
- Minor tweaks to the Self Documenting Selectors section
