### PR TITLE
Change NameFormat to BEM

### DIFF
--- a/css/.scss-lint.yml
+++ b/css/.scss-lint.yml
@@ -100,7 +100,7 @@ linters:
     # (http://bem.info/method/definitions/).
     NameFormat:
         enabled: true
-        convention: hyphenated_lowercase
+        convention: BEM
 
     # Report @extend unless extending a placeholder?
     PlaceholderInExtend:


### PR DESCRIPTION
This is so that variables like `$component__variable-name` can work. Previous rule (`hyphenated_lowercase`) would throw a warning on that variable name.

Status: **Opened for visibility**
Reviewers: @kpeatt @ry5n 
JIRA: **n/a**
## Changes
- Changed `NameFormat` from `hyphenated_lowercase` to `BEM`
