### PR TITLE
Turn off lowercase selectors to avoid warnings

### DIFF
--- a/css/.scss-lint.yml
+++ b/css/.scss-lint.yml
@@ -12,7 +12,7 @@ linters:
 
     # Should selectors be all lowercase?
     CapitalizationInSelector:
-        enabled: true
+        enabled: false
 
     # Prefer hexadecimal color codes over color keywords?
     ColorKeyword:


### PR DESCRIPTION
@jeffkamo — This fixes #30 
