### PR TITLE
Beef up .eslintrc with rules from JS code style doc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,7 @@
+2.1.0
+    - Add new rules to .eslintrc to closer match our JS style
+      guidelines.
+2.0.1
+    - Adds .eslintrc to allow usage of ESLint
+    - Adds Java code style guide
+    - Updates to CSS hybrid project conventions

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -12,6 +12,9 @@
         "Adaptive": true
     },
     "rules": {
+        // K&R brace style, e.g. `if (x) {` <-- no new line before {
+        "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+
         // Enforce === instead of ==; !== instead of !=
         "eqeqeq": 2,
 
@@ -48,6 +51,9 @@
         // Disallow mixed spaces and tabs for indentation
         "no-mixed-spaces-and-tabs": 2,
 
+        // Enforce 4 spaces indentation
+        "indent": [2, 4, {"indentSwitchCase": true}],
+
         // Disallow use of multiline strings
         "no-multi-str": 2,
 
@@ -66,6 +72,9 @@
 
         // Enforce spacing before opening brace of block statements
         "space-before-blocks": [2, "always"],
+
+        // Disallow spaces before function parentheses
+        "space-before-function-paren": [2, "never"],
 
         // Enforce spaceing around infix operators: +, -, :, ?
         "space-infix-ops": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added a couple of rules to `.eslintrc` that were in the JS code style doc but not enforced by the linter.

## No space before function parens
```js
var myfunc = function() {
   code();
}
```

## 4 spaces indentation
```js
if (x) {
    // 4 spaces
    code();
}
```

## K&R brace style
```js
if (x) { // <-- no new line before {
    code();
}
``` 