### PR TITLE
Make IIFE wrap inside to avoid conflict with no-extra-parens

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -26,7 +26,7 @@
         "no-extend-native": 2,
 
         // Enforce wrapping immediate invocations in parentheses
-        "wrap-iife": 2,
+        "wrap-iife": [2, "inside"],
 
         // Disallow usage of a variable before declaration; ignores functions
         "no-use-before-define": [2, "nofunc"],


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @donnielrt @Helen-Mobify 

## Changes
- Our current `wrap-iife` rule defaults to "outside" wrapping required
```
// wrapping the call expression (outside)
return (function () { return { y: 1 };}());
```
However, this will conflict with our rule for `no-extra-parens`, and since the rule is set to "outside" we cannot avoid a linting error since wrapping via inside to avoid `no-extra-parens` i.e.
```
// wrapping the function expression (inside)
return (function () { return { y: 1 };})();
```
will violate the default "outside" rule.
This PR changes our rule to "inside" wrapping so that we may reach a no lint error state.

**TL;DR:** With the "outside" IIFE wrapping rule, you'll always be in an error state. Changing the IIFE rule to "inside" will let us reach a conflict-free state with no lint errors.

## Todos:
- [ ] Engineer +1

## Links:
[Eslint wrap-iife rule](http://eslint.org/docs/rules/wrap-iife)

## How to Test
- Verify that we enter a constant lint error state for IIFEs
- Update your local copy of the code-style by running `npm install -g git+ssh://git@github.com:mobify/mobify-code-style.git#wrap-iife-conflict`
- Verify that we may now wrap IIFEs via "inside" parens, to avoid linting errors
