### PR TITLE
Remove enforcement of max-statements and max-params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.2.2
+    - Remove enforcement of 'max-statements' and 'max-params' JS rules
 2.2.1
     - Cumulative patch release
     - Update SCSS-lint to 0.40.1

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -105,12 +105,6 @@
         // Disallows the nesting of blocks more than 5 deep
         "max-depth": [2, 5],
 
-        // Enforces a maximum of 10 parameters in a function declaration
-        "max-params": [2, 10],
-
-        // Enforces a maximum of 25 statements within a single function
-        "max-statements": [2, 25],
-
         // Enforces a maximum of 100 characters in a single line; adjusts tabs
         // to equal 4 characters
         "max-len": [2, 300, 4],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @donnielrt @Helen-Mobify 

## Changes
- Remove rules for `max-params` and `max-statements`, as these rules do nothing but cause developers to have to explicitly ignore them

## Todos:
- [x] +1
- [x] Prep for release

### Feedback:
_none so far_

## How to Test
- Checkout this code
- Run `npm link`
- Check your code linting and how it uses the new ruleset
