### PR TITLE
Remove parens rule for functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.2.4
+    - Remove the unnecessary parens rule
 2.2.3
     - Restrict the unnecessary parens rule to functions
 2.2.2

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -93,9 +93,6 @@
         // Enforce single quotes for string literals
         "quotes": [2, "single"],
 
-        // Disallow unnecessary parentheses around functions
-        "no-extra-parens": [2, "functions"],
-
         // Disallow unnecessary semicolons
         "no-extra-semi": 2,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Remove parens rule completely as it had some quirky behaviour.