### PR TITLE
Fix indentSwitchCase rule for eslint 1.0.0

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -53,7 +53,7 @@
         "no-mixed-spaces-and-tabs": 2,
 
         // Enforce 4 spaces indentation
-        "indent": [2, 4, {"indentSwitchCase": true}],
+        "indent": [2, 4, {"SwitchCase": 1}],
 
         // Disallow use of multiline strings
         "no-multi-str": 2,


### PR DESCRIPTION
Status: **WIP**
Reviewers: @fractaltheory @haroldtreen 

## Todos:
- [ ] Engineer +1
- [ ] Test with eslint config in a generated project

### Feedback:
_none so far_

## Changes
- Fix busted rule

## How to Test
- Run old .eslintrc file against eslint 1.0.0, observe that it throws an error

<img width="915" alt="screenshot 2015-10-12 14 02 26" src="https://cloud.githubusercontent.com/assets/1524374/10438679/e581fb2e-70e9-11e5-96bd-230fa8b49c43.png">

- Checkout and use this branch, confirm that the error goes away
<img width="973" alt="screenshot 2015-10-12 14 04 35" src="https://cloud.githubusercontent.com/assets/1524374/10438713/2e2530da-70ea-11e5-96f3-fa0a026fc5ea.png">

~ tada ~