### PR TITLE
Add an eslintrc config for production code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.3.1
+    - Add an eslint config file for production-ready JS
 2.3.0
     - Add CSSComb
     - Update documentation

--- a/javascript/.eslintrc-prod
+++ b/javascript/.eslintrc-prod
@@ -1,0 +1,8 @@
+{
+    // Keep all dev rules
+    "extends": "./.eslintrc",
+    "rules": {
+        // Disallow use of debugger statements in production code
+        "no-debugger": 2
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @donnielrt @Helen-Mobify @MikeKlemarewski @fractaltheory 

## Changes
- We currently don't make any distinction in our eslint rulesets between development and production ready code. Certain syntactical and code style errors may be acceptable for dev, but completely bad practice for code destined for prod. Let's make a distinction by adding a new `.eslintrc-prod` that can be referenced in our projects for `lint:prod` tasks.
- Note that the `.eslintrc-prod` ruleset includes all rules from the usual dev `.eslintrc` ruleset
- I will be updating the [Adaptive generator](https://github.com/mobify/generator-adaptivejs) to make use of this prod ruleset once this PR is merged

## Jira Tickets:
- [x] n/a

## Todos:
- [ ] +1

### Feedback:
_none so far_

## How to Test
You can test the separate rulesets by using

`eslint -c ./mobify-code-style/javascript/.eslintrc path/to/file/to/test.js`

to test the dev ruleset, and

`eslint -c ./mobify-code-style/javascript/.eslintrc-prod path/to/file/to/test.js`

to test the prod ruleset

Your test file can be full of `debugger;` statements and it will pass the dev ruleset, but fail the prod ruleset