### PR TITLE
Add rules for prohibiting unused vars/expressions

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -110,6 +110,10 @@
         "semi": 2,
 
         // Disallow function definitions of the form 'function myFunc() {'
-        "func-style": [2, "expression"]
+        "func-style": [2, "expression"],
+
+        // Disallow unused variables/expressions
+        "no-unused-vars": 2,
+        "no-unused-expressions": 2
     }
 }

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -88,6 +88,21 @@ var length = items.length;
 var name = 'foo';
 ````
 
+## Don't have unused variables/expressions
+```javascript
+// Bad: Many of these variables/expressions are useless
+{} // object - not used
+var newArray = []; // newArray - not used
+['1', '2', '3', '4'].forEach(function(num, index) { // index - not used
+    return num++;
+});
+
+// Good: Delete things you no longer need
+['1', '2', '3', '4'].forEach(function(num) {
+    return num++;
+});
+```
+
 ##Use semi-colons
 
 There are many more ways that things can break *without* semi-colons than *with* semi-colons.


### PR DESCRIPTION
# Add no-unused-* rules

Status: **Ready for Review**
Reviewers: @jansepar @donnielrt @marlowpayne 

## Changes:
- Add rules for `no-unused-variables` and `no-unused-expressions`

I have found these rules especially useful when they detect imports I don't use:
eg.
```javascript
define(['somethingUsed', 'somethingUnused'], function(used, unused) { // Linting error!
      used();
});

// OR

var used = require('used');
var unused = require('unused'); // Linting error!

used();
```