### PR TITLE
Change CSSComb rule to disable leading-zero due to bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 2.3.6
     - Change CSScomb rule: disable leading-zero rule due to CSScomb bug
-    - Change scss-lint rule: disable LeadingZero rule to work with CSSComb leading-zero rule
 2.3.5
     - Add Sass documentation about placeholders and `@extends`
     - Add CSS documentation on l10n and i18n best practices

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2.3.6
     - Change CSScomb rule: disable leading-zero rule due to CSScomb bug
+    - Change scss-lint rule: disable LeadingZero rule to work with CSSComb leading-zero rule
 2.3.5
     - Add Sass documentation about placeholders and `@extends`
     - Add CSS documentation on l10n and i18n best practices

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.3.6
+    - Change CSScomb rule: disable leading-zero rule due to CSScomb bug
 2.3.5
     - Add Sass documentation about placeholders and `@extends`
     - Add CSS documentation on l10n and i18n best practices

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 2.3.6
-    - Change CSScomb rule: disable leading-zero rule due to CSScomb bug
+    - Change CSScomb rule: null leading-zero rule due to CSScomb bug
 2.3.5
     - Add Sass documentation about placeholders and `@extends`
     - Add CSS documentation on l10n and i18n best practices

--- a/css/.csscomb.json
+++ b/css/.csscomb.json
@@ -13,7 +13,7 @@
     "combinator-space": [" ", " "],
     "element-case": "lower",
     "eof-newline": true,
-    "leading-zero": true,
+    "leading-zero": false,
     "rule-indent": "    ",
     "stick-brace": " ",
     "unitless-zero": true,

--- a/css/.csscomb.json
+++ b/css/.csscomb.json
@@ -13,7 +13,7 @@
     "combinator-space": [" ", " "],
     "element-case": "lower",
     "eof-newline": true,
-    "leading-zero": false,
+    "leading-zero": null,
     "rule-indent": "    ",
     "stick-brace": " ",
     "unitless-zero": true,

--- a/css/.scss-lint.yml
+++ b/css/.scss-lint.yml
@@ -116,7 +116,7 @@ linters:
     # Lint leading zero on dimension values?
     # Configure: `exclude_zero` or `include_zero`
     LeadingZero:
-        enabled: false
+        enabled: true
         style: include_zero
 
     # Report same selector used twice in a single stylesheet?

--- a/css/.scss-lint.yml
+++ b/css/.scss-lint.yml
@@ -116,7 +116,7 @@ linters:
     # Lint leading zero on dimension values?
     # Configure: `exclude_zero` or `include_zero`
     LeadingZero:
-        enabled: true
+        enabled: false
         style: include_zero
 
     # Report same selector used twice in a single stylesheet?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Change CSSComb rule to disable leading-zero due to bug

Status: **Ready for Review**
Reviewers: @marlowpayne @jeffkamo 

## Changes:
- Change CSScomb rule: disable leading-zero rule due to CSScomb bug

## Bug:
For example, I want to write `margin: $unit*1.5` and with CSSComb, it will rewrite to `margin: $unit*10.5`. It should not add 0 in this case, changes visual big time. 

## How to test:
- cd to mobify-code-style
- `npm link` to update CSSComb rules.