### PR TITLE
Fix the point about function expression hoisting

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -109,7 +109,7 @@ a = b;
 
 The function expression is clearly recognisable as what it really is (a variable with a function value). Additionally, it helps organize code so that all variable declarations appear at the top of a file, and invocations follow. This gives some predictablity when others are reading your code, allowing for a more consistent structure.
 
-Function expressions are subject to [hoisting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting), and as such declaring functions as expressions will result in their being hoisted to the top of their enclosing function or global code.
+Function expressions are not subject to [hoisting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function#Function_declaration_hoisting). This encourages developers to declare functions before invoking them.
 
 
 ````javascript


### PR DESCRIPTION
# Fix the point about function expression hoisting

Status: **Up For Review**

Reviewers: @jansepar 

## Changes
- In javascript, function expressions are not hoisted, but function declarations are. This doc said the exact opposite of that. I updated the doc with the correct info.

## How to test-drive this PR
- Read the section`Use function expressions over function declarations` and make sure it makes sense. 

## Research resources
- [Function declaration hoisting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function#Function_declaration_hoisting)