### PR TITLE
Add reference to Swift API design guidelines.

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -1,4 +1,4 @@
-The Mobify style guide for Swift is largely embodied in the [Astro](mobify/astro) Swift code. Think of that codebase as "canonical" Swift code.
+The Mobify style guide for Swift is largely embodied in the [Astro](github.com/mobify/astro) Swift code. Think of that codebase as "canonical" Swift code.
 
 We also follow the [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/) in all of the code we write.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,4 +1,4 @@
-The Mobify style guide for Swift is largely embodied in the [Astro](github.com/mobify/astro) Swift code. Think of that codebase as "canonical" Swift code.
+The Mobify style guide for Swift is largely embodied in the [Astro](https://github.com/mobify/astro) Swift code. Think of that codebase as "canonical" Swift code.
 
 We also follow the [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/) in all of the code we write.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,3 +1,7 @@
+The Mobify style guide for Swift is largely embodied in the [Astro](mobify/astro) Swift code. Think of that codebase as "canonical" Swift code.
+
+We also follow the [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/) in all of the code we write.
+
 Strings
 =======
 


### PR DESCRIPTION
Adds a reference to the recently published Swift API design guidelines on swift.org. 

If we don't already follow these in all of our code, we definitely should. :)