### PR TITLE
Add eslint rule and doc for trailing commas

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.4.3
+    - Add eslint rule + doc entry regarding trailing commas
 2.4.2
     - Add/update documentation for Sass-Lint
 2.4.1

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -110,6 +110,9 @@
         "semi": 2,
 
         // Disallow function definitions of the form 'function myFunc() {'
-        "func-style": [2, "expression"]
+        "func-style": [2, "expression"],
+
+        // Enforce trailing comma style
+        "comma-style": [2, "last"]
     }
 }

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -105,6 +105,32 @@ a = b;
 (f());
 ```
 
+##Use trailing commas
+
+For multi-line lists or object properties place the commas separating items at the end of the line of the previous item.
+
+```javascript
+// bad
+var foo = ["apples"
+           , "oranges"
+           , "bananas"];
+
+var foo = {
+    "fruit": "apple"
+    , "vegetable": "arugula"
+};
+
+// good
+var foo = ["apples",
+           "oranges",
+           "bananas"];
+
+var foo = {
+    "fruit": "apple",
+    "vegetable": "arugula"
+};
+```
+
 ##Use function expressions over function declarations
 
 The function expression is clearly recognisable as what it really is (a variable with a function value). Additionally, it helps organize code so that all variable declarations appear at the top of a file, and invocations follow. This gives some predictablity when others are reading your code, allowing for a more consistent structure.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Code style guide and linting tools for Mobify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reviewers: @jansepar @jeremywiebe @MikeKlemarewski @mikenikles 

## Changes
- Add a rule to eslint to enforce trailing comma style. Rule [ref here](http://eslint.org/docs/rules/comma-style)
- Add a note to the JS style doc with a couple examples

## Todos:
- [x] +1
- [x] Update Changelog
- [x] Update `package.json`

## How to Test
- Checkout code
- Proofread doc changes
- Test in a project by:
  - Update entry for code-style in `package.json` to reference this branch: 

    `"mobify-code-style": "git+https://github.com/mobify/mobify-code-style.git#trailing-commas"`

  - Refresh code-style dep: `rm -rf node_modules/mobify-code-style && npm install`
  - Use leading commas in a JS file that is being linted
  - Run JS linter to check for the lint: Usually `grunt lint`