### PR TITLE
Remove length restriction & strict rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 2.5.1
-    - Remove line length restriction
+    - Update line length to 200
     - Remove 'strict' rule for modules
 2.5.0
     - Add an ES6 and JSX standard with lint rules.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.5.1
+    - Remove line length restriction
+    - Remove 'strict' rule for modules
 2.5.0
     - Add an ES6 and JSX standard with lint rules.
 2.4.4

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -141,9 +141,6 @@ rules:
   max-depth:
     - error
     - max: 5
-  max-len:
-    - error
-    - code: 100
   max-nested-callbacks:
     - error
     - max: 3
@@ -188,7 +185,6 @@ rules:
   space-infix-ops: error
   space-unary-ops: error
   spaced-comment: error
-  strict: error
   template-curly-spacing: error
   unicode-bom:
     - error

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -18,6 +18,7 @@ rules:
   # Avoid possible import problems:
   import/no-extraneous-dependencies: error
   import/no-duplicates: error
+  import/no-unresolved: 'off'
   no-duplicate-imports: error
 
   # Stick with ES6 module syntax

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -141,6 +141,9 @@ rules:
   max-depth:
     - error
     - max: 5
+  max-len:
+    - error
+    - code: 200
   max-nested-callbacks:
     - error
     - max: 3


### PR DESCRIPTION
Linked PRs: (links to corresponding PRs, optional)

## Changes
- Remove line length restriction. This turned out to be a pain almost immediately. Long lines should be caught in code review if they go beyond your laptop screen width.
- Remove the `strict` rule as sometimes we need 'use strict' in modules that are run through node.

## How To Test
- Checkout this branch and run `npm link`
- In a project that includes mobify-code style: run `npm link mobify-code-style`
- Write a line that is longer than 100 characters and run the lint rules, make sure they pass
- Add a 'use strict' declaration to the top of a module, run the lint rules and make sure they pass

## TODOs:
- [ ] +1
- [ ] Updated README
- [ ] Updated CHANGELOG