### PR TITLE
Minor ES6 fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.5.2
+    - Update ES6 indent rule on switch statements
 2.5.1
     - Update line length to 200
     - Remove 'strict' rule for modules

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.5.2
     - Update ES6 indent rule on switch statements
     - Add ignore patterns for unused vars/args to the React configuration
+    - Ignore non-JS files and node_modules in the ES6 import module
 2.5.1
     - Update line length to 200
     - Remove 'strict' rule for modules

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2.5.2
     - Update ES6 indent rule on switch statements
+    - Add ignore patterns for unused vars/args to the React configuration
 2.5.1
     - Update line length to 200
     - Remove 'strict' rule for modules

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We use [ESLint](http://eslint.org/) to lint ES6 and React/JSX code. If ESLint is
 ```yaml
 extends:
   - './node_modules/mobify-code-style/es6/mobify-es6.yml'
-```  
+```
 
 and for a React/JSX project:
 
@@ -45,6 +45,15 @@ and for a React/JSX project:
 extends:
   - './node_modules/mobify-code-style/es6/mobify-es6-react.yml'
 ```
+
+If using a custom Webpack configuration, add the lines:
+```yaml
+settings:
+  import/resolver:
+    webpack:
+      config: '<path-to-webpack-config>'
+```
+to the `.eslintrc.yml`
 
 Make sure to install the following NPM modules:
  - `eslint` > 3.0

--- a/es6/mobify-es6-react.yml
+++ b/es6/mobify-es6-react.yml
@@ -34,3 +34,9 @@ rules:
   react/jsx-indent-props: error
   react/jsx-space-before-closing: error
   react/wrap-multilines: error
+
+  # Ignore common unused vars and args in React projects
+  no-unused-vars:
+    - error
+    - varsIgnorePattern: '^(styles)$'
+      argsIgnorePattern: '^(props|dispatch|state)$'

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -132,7 +132,10 @@ rules:
   dot-notation: error
   eol-last: error
   generator-star-spacing: error
-  indent: error
+  indent:
+    - error
+    - 4
+    - SwitchCase: 1
   jsx-quotes: error
   key-spacing: error
   keyword-spacing: error

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -11,6 +11,9 @@ parserOptions:
   sourceType: module
 settings:
   import/resolver: webpack
+  import/ignore:
+    - node_modules
+    - \.(scss|css|html)$
 rules:
   # Allow logging for debug purposes
   no-console: 'off'


### PR DESCRIPTION
This PR pulls in changes to the ES6 linting rules that we've found necessary developing the Progressive Web SDK and Scaffold. 

## Changes
- Update the indent rule for consistency with ES5
- Ignore unused `props`, `dispatch`, and `state` arguments, and unused `styles` variables/imports in React projects
- Do not lint imports from the `node_modules` directory and non-JS files.


## TODOs:
- [x] +1
- [x] Updated README
- [x] Updated CHANGELOG
