### PR TITLE
Fix #114: Provide valid options for CSSComb config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+Pending Release:
+    - Fix #114 by removing invalid options from CSSComb config file
 2.5.1
     - Update line length to 200
     - Remove 'strict' rule for modules

--- a/css/.csscomb.json
+++ b/css/.csscomb.json
@@ -13,11 +13,9 @@
     "combinator-space": [" ", " "],
     "element-case": "lower",
     "eof-newline": true,
-    "leading-zero": null,
     "rule-indent": "    ",
     "stick-brace": " ",
     "unitless-zero": true,
-    "quotes": false,
     "remove-empty-rulesets": true,
     "space-before-closing-brace": "\n",
     "space-before-colon": "",
@@ -29,7 +27,7 @@
     "space-after-selector-delimiter": "\n",
     "space-before-selector-delimiter": "",
     "strip-spaces": true,
-    "tab-size": true,
+    "tab-size": 4,
     "unitless-zero": true,
     "sort-order": [
         [


### PR DESCRIPTION
## Changes
- Fixes #114 by removing invalid options from CSSComb config

## How To Test
- Checkout this change
- Reference it when running CSSComb on the command line:
`csscomb -c node_modules/mobify-code-style/css/.csscomb.json src/sass/`
- Make sure that no invalid option errors surface
- Try it in a text editor (Internal [wiki link](https://mobify.atlassian.net/wiki/display/LT/CSSComb) for setting up CSSComb in your editor)

## TODOs:
- [x] +1
- [x] ~~Updated README~~
- [x] Updated CHANGELOG

