### PR TITLE
Enable sort-prop-types rule.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.5.2
+    - Add a React rule to make sure propTypes are ordered, required ones declared first and callbacks (e.g. onChange) declared last.
 2.5.1
     - Update line length to 200
     - Remove 'strict' rule for modules

--- a/es6/mobify-es6-react.yml
+++ b/es6/mobify-es6-react.yml
@@ -25,6 +25,10 @@ rules:
   react/no-string-refs: error
   react/prefer-es6-class: error
   react/prefer-stateless-function: error
+  react/sort-prop-types:
+    - error
+    - callbacksLast: true
+      requiredFirst: true
 
   # JSX formatting preferences
   react/self-closing-comp: error


### PR DESCRIPTION
Since we add comments for each prop type declaration, there's quite a number of lines to scan when looking for a prop type.
This ESLint rule enforces two things:

1. [callbacksLast](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md#callbackslast)
1. [requiredFirst](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md#requiredfirst)

## Changes
- Added the `react/sort-prop-types` rule.

## How To Test
- Define `propTypes` in non-alphabetical order.
- Define `propTypes` with callbacks at the top, such as `onChange`.
- Define `propTypes` with optional types at the top, and `isRequired` types further down.
- Make sure ESLint reports each of the above scenario.

## Applicable Research Resources
- https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md

## TODOs:
- [x] +1
- [ ] ~~Updated README~~ (not necessary)
- [x] Updated CHANGELOG
