### PR TITLE
Fix #123 by using updated rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+Pending Release
+    - Fix #123 by using react/jsx-wrap-multilines rule
 2.5.2
     - Fix #43 by updating all underlines in Sass code examples
     - Fix #114 by removing invalid options from CSSComb config file

--- a/es6/mobify-es6-react.yml
+++ b/es6/mobify-es6-react.yml
@@ -37,7 +37,7 @@ rules:
   react/jsx-indent: error
   react/jsx-indent-props: error
   react/jsx-space-before-closing: error
-  react/wrap-multilines: error
+  react/jsx-wrap-multilines: error
 
   # Ignore common unused vars and args in React projects
   no-unused-vars:


### PR DESCRIPTION
## Changes
- Fix #123 by updating `react/wrap-multilines` to `react/jsx-wrap-multilines`

## How To Test
- Point the Progressive SDK linting to use this branch's code (it is using `eslint-plugin-react` v6.0.0)
- `rm -rf node_modules/mobify-code-style && npm install`
- `npm run lint`
- Make sure there are no rule warnings

## Applicable Research Resources
- https://github.com/yannickcr/eslint-plugin-react/releases/tag/v6.0.0

## TODOs:
- [x] +1
- [x] ~~Updated README~~
- [x] Updated CHANGELOG

