### PR TITLE
Remove variable-for-property sass-lint rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+Pending Release
+    - Remove `variable-for-property` rule from sass-lint
 2.5.3
     - Fix #123 by using react/jsx-wrap-multilines rule
     - Migrate CSSComb documentation from Confluence to code style repo

--- a/css/.sass-lint.yml
+++ b/css/.sass-lint.yml
@@ -323,9 +323,7 @@ rules:
   trailing-semicolon: 2
   url-quotes: 1 # Only warn here, since sass-lint doesn't understand helpers in urls
   variable-for-property:
-    - 2
-    - properties:
-        - font
+    - 0
   variable-name-format:
     - 2
     - allow-leading-underscore: true


### PR DESCRIPTION
## Changes
- We often inherit `font`, so let's not enforce a variable to be used

## How To Test
- Checkout code
- `npm link`
- Test for the rule removal in your editor

## Applicable Research Resources
- [Variable For Property doc](https://github.com/sasstools/sass-lint/blob/develop/docs/rules/variable-for-property.md)

## TODOs:
- [x] +1
- [x] Updated README
- [x] Updated CHANGELOG

