### PR TITLE
Fix `lint-md` so it works no matter how/where it's invoked

### DIFF
--- a/bin/lint-md
+++ b/bin/lint-md
@@ -1,1 +1,0 @@
-../docs/bin/lint-md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-> Write great documentation! – * [_Mobify Developer Values_](https://github.com/mobify/developer-values#️-write-great-documentation)
+> Write great documentation! – \* [_Mobify Developer Values_](https://github.com/mobify/developer-values#️-write-great-documentation)
 
 At Mobify, documentation is written in markdown.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ docs.mobify.com.
 
 To make writing document easier, we provide:
 
-* A linter for consistent markdown style.
-* A writing checklist for consistent process.
+- A linter for consistent markdown style.
+- A writing checklist for consistent process.
 
 ### Markdown Linting
 
@@ -32,22 +32,24 @@ npm install --save-dev mobify-code-style
 **Before you start writing**
 
 Write down the goal of your document.
-* Does a similar document exist? Could it be extended to meet the goal?
-* Does your document fit in an existing category? If so, which one?
+
+- Does a similar document exist? Could it be extended to meet the goal?
+- Does your document fit in an existing category? If so, which one?
 
 Who is your audience? What is their skill level?
 
 What kind of document best meets your goal?
-* [Step-by-step tutorials](https://jacobian.org/writing/what-to-write/#tutorials)
-* [Overview or topical guide to a conceptual area](https://jacobian.org/writing/what-to-write/#topical-guides)
-* [Low-level, deep-dive reference material](https://jacobian.org/writing/what-to-write/#reference)
+
+- [Step-by-step tutorials](https://jacobian.org/writing/what-to-write/#tutorials)
+- [Overview or topical guide to a conceptual area](https://jacobian.org/writing/what-to-write/#topical-guides)
+- [Low-level, deep-dive reference material](https://jacobian.org/writing/what-to-write/#reference)
 
 **While writing**
 
-* [Write like you talk](http://paulgraham.com/talk.html).
-* [Only use terms from the glossary](https://docs.google.com/document/d/1xbHkio-hdps-5zZG-SmmAKbR9WpXtrJJ-fprShN7NkM/edit).
+- [Write like you talk](http://paulgraham.com/talk.html).
+- [Only use terms from the glossary](https://docs.google.com/document/d/1xbHkio-hdps-5zZG-SmmAKbR9WpXtrJJ-fprShN7NkM/edit).
 
 **After writing**
 
-* [ ] 👍 Review
-* [ ] 🍻 Celeberate
+- [ ] 👍 Review
+- [ ] 🍻 Celeberate

--- a/docs/bin/lint-md
+++ b/docs/bin/lint-md
@@ -2,18 +2,23 @@
 
 # Lints Markdown files using Mobify's `.remarkrc` configuration.
 BIN="${BASH_SOURCE[0]}"
-BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"
 
 # We jump through some hoops here because we symlink the node module's
 # bin into the docs/bin/ directory and we want to support invoking
 # via the symlink and directly via `/docs/bin/lint-md`
-if [ -h "$BIN" ]; then
+while [ -h "$BIN" ]; do
     # Dereference the symlink
-    BIN="$BIN_DIR/$(readlink "$BIN")"
-fi
-BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"
+    BIN="$(cd "$(dirname "$BIN")" && pwd)/$(readlink "$BIN")"
+done
 
-REMARK_RC="$BIN_DIR/../remarkrc"
-REMARK_CLI="$(npm bin)/remark"
+DOCS_DIR="$(cd "$(dirname "$BIN")/.." && pwd)"
+REMARK_RC="$DOCS_DIR/remarkrc"
+
+# This is tricky. `remark` is a dep of mobify-code-style
+# and so won't show up in `node_modules/.bin` of a project
+# that uses mobify-code-style. We have to move into the
+# the mobify-code-style /docs directory and find the npm
+# bin directory relative that _that_ to find remark!
+REMARK_CLI="$(cd "$DOCS_DIR" && npm bin)/remark"
 
 $REMARK_CLI --rc-path $REMARK_RC "$@"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/mobify/mobify-code-style/issues"
   },
   "bin": {
-    "lint-md": "./bin/lint-md"
+    "lint-md": "docs/bin/lint-md"
   },
   "homepage": "https://github.com/mobify/mobify-code-style",
   "scripts": {


### PR DESCRIPTION
Linked PRs: https://github.com/mobify/mobify-code-style/pull/138

## Changes
- `lint-md` was sensitive to how it was invoked (via symlink installed in `node_modules/.bin`, via the symlink in `mobify-code-style/bin`, directly via `mobify-code-style/docs/bin`). This PR fixes it so that it first derefences back to the actual script location so that it can find associated files in the `mobify-code-style/docs/` directory.

## How To Test
- Run the `lint-md` command using the various symlinks. 
  - Run the script directly against some markdown docs: `mobify-code-style/docs/bin/lint-md mydocs`
  - Run the script using the symlink in `mobify-code-style/bin/lint-md`
  - Install the `mobify-code-style` npm package using this branch and run `node_modules/.bin/lint-md`
    - `package.json` -> `'mobify-code-style': 'mobify/mobify-code-style#fix-lint-md`

All three methods of running the script should work, should properly find the `remarkrc` file, and should produce warnings/errors in the markdown files passed to it.

## Applicable Research Resources
- N/A

## TODOs:
- [ ] +1
- [ ] Updated README
- [ ] Updated CHANGELOG
- [ ] (Other applicable TODOs)

