### PR TITLE
Temporarily downgrade `spaced-comment` errors to warning level, until it complies with Astro release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.7.2
+    - Temporarily downgrade `spaced-comment` errors to warning level, until Astro release builds comply with this rule.
 2.7.1
     - Re-organized and cleaned up markdown linting files
     - Switched to using `no-duplicate-headings-in-section` (instead of `no-duplicate-headings`)

--- a/es5/mobify-es5.yml
+++ b/es5/mobify-es5.yml
@@ -46,7 +46,7 @@ rules:
     - never
   space-infix-ops: error
   space-unary-ops: error
-  spaced-comment: error
+  spaced-comment: warn
   no-undef: error
   eol-last: warn
   quotes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-code-style",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Code style guide and linting tools for Mobify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes
- Temporarily downgrade `spaced-comment` errors to warning level, until it complies with Astro release

## How To Test

## Applicable Research Resources
- (links, optional)

## TODOs:
- [ ] +1
- [ ] Updated README
- [x] Updated CHANGELOG