### PR TITLE
Fix doc linting in node 6

### DIFF
--- a/docs/bin/lint-md
+++ b/docs/bin/lint-md
@@ -14,11 +14,16 @@ done
 DOCS_DIR="$(cd "$(dirname "$BIN")/.." && pwd)"
 REMARK_RC="$DOCS_DIR/remarkrc"
 
-# This is tricky. `remark` is a dep of mobify-code-style
-# and so won't show up in `node_modules/.bin` of a project
-# that uses mobify-code-style. We have to move into the
-# the mobify-code-style /docs directory and find the npm
-# bin directory relative that _that_ to find remark!
-REMARK_CLI="$(cd "$DOCS_DIR" && npm bin)/remark"
+if [[ $(node -v) =~ ^v4 ]]; then
+	# Node v4!!
+	# This is tricky. `remark` is a dep of mobify-code-style
+	# and so won't show up in `node_modules/.bin` of a project
+	# that uses mobify-code-style. We have to move into the
+	# the mobify-code-style /docs directory and find the npm
+	# bin directory relative that _that_ to find remark!
+    REMARK_CLI="$(cd "$DOCS_DIR" && npm bin)/remark"
+else
+    REMARK_CLI="$(npm bin)/remark"
+fi
 
 $REMARK_CLI --rc-path $REMARK_RC "$@"

--- a/docs/bin/lint-md
+++ b/docs/bin/lint-md
@@ -14,7 +14,7 @@ done
 DOCS_DIR="$(cd "$(dirname "$BIN")/.." && pwd)"
 REMARK_RC="$DOCS_DIR/remarkrc"
 
-if [[ $(node -v) =~ ^v4 ]]; then
+if [[ $(node -v) =~ ^v[0-4] ]]; then
 	# Node v4!!
 	# This is tricky. `remark` is a dep of mobify-code-style
 	# and so won't show up in `node_modules/.bin` of a project


### PR DESCRIPTION
Linked PRs: N/A

## Changes
- In node 4 and earlier `node_modules` are nested (each module has its own `node_modules` folder with its dependencies.  In node 6 all dependencies are in a flattened, top-level `node_modules`.  This PR fixes the `lint-md` command so that it can always find the `remark` binary.

## How To Test
- Reference this branch of `mobify-code-style` in the Astro project
- Switch to node 4 and run `rm -rf node_modules; npm install && npm run docs:lint`
- Switch to node 6 and run `rm -rf node_modules; npm install && npm run docs:lint`
- Both will result in a ton of linting errors, but you should not see a node error saying it cannot find `remark`

## Applicable Research Resources
- N/A

## TODOs:
- [ ] +1
~~- [ ] Updated README~~
~~- [ ] Updated CHANGELOG~~
~~- [ ] (Other applicable TODOs)~~
