### PR TITLE
Patch to --update flag in copyright tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## To be released
+- Fixes whitespace / newline management in copyright tool
+- Fix to additional space added when --update flag passed into copyright tool
+
 ## v2.8.0 (May 5, 2017)
 - Adds new copyright-header management tool
 

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -16,7 +16,7 @@ const blackBG = '\x1b[40m'
 const defaultBG = '\x1b[49m'
 const defaultFG = '\x1b[39m'
 
-const currentYear = 2018 // new Date().getFullYear()
+const currentYear = new Date().getFullYear()
 const langs = {}
 
 let lintMode = true

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
@@ -17,7 +16,7 @@ const blackBG = '\x1b[40m'
 const defaultBG = '\x1b[49m'
 const defaultFG = '\x1b[39m'
 
-const currentYear = new Date().getFullYear()
+const currentYear = 2018 // new Date().getFullYear()
 const langs = {}
 
 let lintMode = true
@@ -105,13 +104,15 @@ args
         const content = fs.readFileSync(file)
         const hasCopyrightHeader = content.includes('Copyright (c)')
         const ext = file.match(/\.[0-9a-z]+$/i)[0]
-
         let newData = ''
 
         if (hasCopyrightHeader && updateMode) {
-            newData = content.toString().replace(/(\(c\)\s)(\d{4})/, `$1 ${currentYear}`)
-            fs.writeFileSync(file, newData)
-            console.log(`${green}Copyright header succesfully updated to ${currentYear} in ${magenta}${file}`)
+            let previousHeaderYear = content.toString().match(/(?:\(c\))(?:\s)(\d{4})/)[1]
+            if (previousHeaderYear !== currentYear.toString()) {
+                newData = content.toString().replace(`(c) ${previousHeaderYear}`, `(c) ${currentYear}`)
+                fs.writeFileSync(file, newData)
+                console.log(`${green}Copyright header succesfully updated from ${previousHeaderYear} to ${currentYear} in ${magenta}${file}`)
+            }
         }
 
         if (!hasCopyrightHeader) {
@@ -125,7 +126,7 @@ args
                 if (contentStr[0].indexOf('#!') >= 0) {
                     const shebang = contentStr.shift()
                     contentStr = contentStr.join('\n')
-                    newData = shebang + '\n\n' + getHeaderText(ext) + '\n' + contentStr // eslint-disable-line prefer-template
+                    newData = shebang + '\n' + getHeaderText(ext) + '\n' + contentStr // eslint-disable-line prefer-template
                 } else {
                     newData = getHeaderText(ext) + `\n${content}`  // eslint-disable-line prefer-template
                 }

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -69,11 +69,11 @@ const buildSupportedExtensions = () => {
  * @return {String}         new file with no leading \n
  */
 const removeLeadingNewlines = (content) => {
-    if (content[0] === '') {
-        content.shift()
-        removeLeadingNewlines(content)
+    if (content[0] !== '') {
+        return content
     }
-    return content
+    content.shift()
+    return removeLeadingNewlines(content)
 }
 
 if (args.length === 0 || args.indexOf('--help') >= 0) {

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -138,11 +138,9 @@ args
                 // accomodate for shebang and insert before header
                 if (contentStr[0].indexOf('#!') >= 0) {
                     const shebang = contentStr.shift()
-                    debugger
                     contentStr = removeLeadingNewlines(contentStr).join('\n')
                     newData = shebang + '\n' + getHeaderText(ext) + '\n' + contentStr // eslint-disable-line prefer-template
                 } else {
-                    debugger
                     contentStr = removeLeadingNewlines(contentStr).join('\n')
                     newData = getHeaderText(ext) + `\n${contentStr}`  // eslint-disable-line prefer-template
                 }

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -62,6 +62,19 @@ const buildSupportedExtensions = () => {
         })
 }
 
+/**
+ * Removes extra \n characters from the top of any files
+ * to ensure more consistent spacing between copyright headers
+ * @param  {String} content original file to edit
+ * @return {String}         new file with no leading \n
+ */
+const removeLeadingNewlines = (content) => {
+    if (content[0] === '') {
+        content.shift()
+        removeLeadingNewlines(content)
+    }
+    return content
+}
 
 if (args.length === 0 || args.indexOf('--help') >= 0) {
 
@@ -125,10 +138,13 @@ args
                 // accomodate for shebang and insert before header
                 if (contentStr[0].indexOf('#!') >= 0) {
                     const shebang = contentStr.shift()
-                    contentStr = contentStr.join('\n')
+                    debugger
+                    contentStr = removeLeadingNewlines(contentStr).join('\n')
                     newData = shebang + '\n' + getHeaderText(ext) + '\n' + contentStr // eslint-disable-line prefer-template
                 } else {
-                    newData = getHeaderText(ext) + `\n${content}`  // eslint-disable-line prefer-template
+                    debugger
+                    contentStr = removeLeadingNewlines(contentStr).join('\n')
+                    newData = getHeaderText(ext) + `\n${contentStr}`  // eslint-disable-line prefer-template
                 }
 
                 fs.writeFileSync(file, newData)


### PR DESCRIPTION
Linked PRs: https://github.com/mobify/progressive-web-sdk/pull/622/ , https://github.com/mobify/platform-scaffold/pull/572,  and https://github.com/mobify/mobify-code-style/pull/155

## Changes
- Fixed extra space being added by copyright tool when passing `--update` 
- Made `\n` addition more consistent (no spaces above header, 1 below header)
- Strips extra `\n` characters which would cause undesirable extra space between headers and content
- Added check to only update year if previous header's year is different 

## How To Test
- Clone this repo
- `cd mobify-code-style/copyright`
- Run `node copyright.js 'someGlob'` with optional `--fix` flag, and `someGlob` pointing to a project
- Hardcode `const currentYear` in `copyright.js` to equal `2018`
- Run `node copyright.js 'someGlob'` with optional `--update` flag, and `someGlob` the same as previous step
- Ensure that the year is correctly updated

## TODOs:
- [x] +1
- [x] Updated CHANGELOG
