### PR TITLE
Update copyright tool's lint failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Provided more detailed linting error message in copyright header tool
+
 ## v2.8.1 (May 8, 2017)
 - Fixes whitespace / newline management in copyright tool
 - Fix to additional space added when --update flag passed into copyright tool

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -20,7 +20,6 @@ const currentYear = new Date().getFullYear()
 const langs = {}
 
 let lintMode = true
-let updateMode = false
 let error = false
 
 // we don't want to pass node and copyright.js directories to the glob
@@ -89,7 +88,6 @@ if (args.length === 0 || args.indexOf('--help') >= 0) {
         Options:
 
             --fix        run in fix mode
-            --update     update the year in existing headers
 
     Visit ${cyan}https://github.com/mobify/mobify-code-style${defaultFG} to learn more.
 `)
@@ -103,11 +101,6 @@ if (args.indexOf('--fix') >= 0) {
     lintMode = false
 }
 
-if (args.indexOf('--update') >= 0) {
-    args.splice(args.indexOf('--update'), 1)
-    updateMode = true
-}
-
 buildSupportedExtensions()
 
 args
@@ -119,7 +112,7 @@ args
         const ext = file.match(/\.[0-9a-z]+$/i)[0]
         let newData = ''
 
-        if (hasCopyrightHeader && updateMode) {
+        if (hasCopyrightHeader && !lintMode) {
             let previousHeaderYear = content.toString().match(/(?:\(c\))(?:\s)(\d{4})/)[1]
             if (previousHeaderYear !== currentYear.toString()) {
                 newData = content.toString().replace(`(c) ${previousHeaderYear}`, `(c) ${currentYear}`)
@@ -152,7 +145,7 @@ args
     })
 
 if (error) {
-    console.log(`${red}${blackBG}ERROR${defaultBG} - Please run the copyright headers tool in this project`)
+    console.log(`${red}${blackBG}ERROR${defaultBG} - Some source files are missing copyright headers. Please run 'copyright --fix' on these files. Mobify projects are configured with an npm run task named 'copyright:fix' that you can use to do this.`)
     process.exit(1)
 } else {
     console.log(`${cyan}Copyright headers are present in target files`)

--- a/copyright/copyright.js
+++ b/copyright/copyright.js
@@ -20,6 +20,7 @@ const currentYear = new Date().getFullYear()
 const langs = {}
 
 let lintMode = true
+let updateMode = false
 let error = false
 
 // we don't want to pass node and copyright.js directories to the glob
@@ -88,6 +89,7 @@ if (args.length === 0 || args.indexOf('--help') >= 0) {
         Options:
 
             --fix        run in fix mode
+            --update     update the year in existing headers
 
     Visit ${cyan}https://github.com/mobify/mobify-code-style${defaultFG} to learn more.
 `)
@@ -101,6 +103,11 @@ if (args.indexOf('--fix') >= 0) {
     lintMode = false
 }
 
+if (args.indexOf('--update') >= 0) {
+    args.splice(args.indexOf('--update'), 1)
+    updateMode = true
+}
+
 buildSupportedExtensions()
 
 args
@@ -112,7 +119,7 @@ args
         const ext = file.match(/\.[0-9a-z]+$/i)[0]
         let newData = ''
 
-        if (hasCopyrightHeader && !lintMode) {
+        if (hasCopyrightHeader && updateMode) {
             let previousHeaderYear = content.toString().match(/(?:\(c\))(?:\s)(\d{4})/)[1]
             if (previousHeaderYear !== currentYear.toString()) {
                 newData = content.toString().replace(`(c) ${previousHeaderYear}`, `(c) ${currentYear}`)


### PR DESCRIPTION
## Update to copyright tool's lint failure message 

Linked PRs: https://github.com/mobify/mobify-code-style/pull/155

## Changes
- Added a more descriptive error message to Mobify's copyright tool when the linting fails

## TODOs:
- [ ] +1
- [x] Updated CHANGELOG