### PR TITLE
Enforce ordering of imports

### DIFF
--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -24,6 +24,12 @@ rules:
   import/no-unresolved: 'off'
   no-duplicate-imports: error
 
+  # Enforce some ordering of imports
+  import/order:
+    - error
+    - newlines-between: always
+  import/first: error
+
   # Stick with ES6 module syntax
   import/no-amd: error
   import/no-commonjs: error


### PR DESCRIPTION
Enforces that imports are grouped and separated with some logic. We use the default ordering as defined in this section of the docs: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#groups-array

`import/first` ensures that all imports occur before any statements.

Basically this:
```js
/* eslint import/order: ["error", {"newlines-between": "always"}] */
import fs from 'fs'
import path from 'path'

import sibling from './foo'

import index from './'
```

## Changes
- Adds enforcement of `import` ordering so that they have some structure and logic

## How To Test
- (necessary config changes)
- (necessary corresponding PRs)
- (how to access the new / changed functionality -- fixtures, URLs)

## Applicable Research Resources
- (links, optional)

## TODOs:
- [ ] +1
- [ ] Updated README
- [ ] Updated CHANGELOG
- [ ] (Other applicable TODOs)
