### PR TITLE
DESKTOP-129: the title is wrong so everything is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.8.5 (April 30, 2018)
+## To Be Released
 - Add in Responsive Best Practices section, updated references to Adaptive [#165](https://github.com/mobify/mobify-code-style/pull/165)
 
 ## v2.8.4 (October 31, 2017)


### PR DESCRIPTION
The CHANGELOG heading was broken so I can't release my updates. I changed it.