### PR TITLE
Remove confusing lint rules

### DIFF
--- a/es5/mobify-es5.yml
+++ b/es5/mobify-es5.yml
@@ -47,7 +47,6 @@ rules:
   space-infix-ops: error
   space-unary-ops: error
   no-undef: error
-  eol-last: warn
   quotes:
     - error
     - single

--- a/es6/mobify-es6-react.yml
+++ b/es6/mobify-es6-react.yml
@@ -25,10 +25,6 @@ rules:
   react/no-string-refs: error
   react/prefer-es6-class: error
   react/prefer-stateless-function: error
-  react/sort-prop-types:
-    - error
-    - callbacksLast: true
-      requiredFirst: true
 
   # JSX formatting preferences
   react/self-closing-comp: error

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -139,7 +139,6 @@ rules:
     - error
     - property
   dot-notation: error
-  eol-last: error
   generator-star-spacing: error
   indent:
     - error
@@ -168,7 +167,6 @@ rules:
   no-spaced-func: error
   no-trailing-spaces: error
   no-whitespace-before-property: error
-  object-curly-spacing: error
   operator-linebreak:
     - error
     - after

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -87,9 +87,6 @@
         // Disallow undeclared variables (unless mentioned in /*global ...*/ comment)
         "no-undef": 2,
 
-        // Warn if single newline at end of file is missing
-        "eol-last": 1,
-
         // Enforce single quotes for string literals
         "quotes": [2, "single"],
 

--- a/javascript/.eslintrc-reset
+++ b/javascript/.eslintrc-reset
@@ -149,7 +149,6 @@
         "comma-spacing": 0,                             // enforce spacing before and after comma ***
         "comma-style": 0,                               // enforce one true comma style ***
         "consistent-this": 0,                           // enforces consistent naming when capturing the current execution context ***
-        "eol-last": 0,                                  // enforce newline at the end of file, with no multiple empty lines
         "func-names": 0,                                // require function expressions to have a name
         "func-style": 0,                                // enforces use of function declarations or expressions ***
         "key-spacing": 0,                               // enforces spacing between keys and values in object literal properties ***


### PR DESCRIPTION
## Changes
- Move lint rule on curly brace formatting that is incompatible with Prettier
- Remove lint rules that require a newline at the end of the file and sorted proptypes

## How To Test
- Clone this repo and check out this branch
- Run npm link inside the `mobify-code-style`
- In any project that has `mobify-code-style` as a dependency, run `npm link mobify-code-style`
- Open any source file in the project and try to trigger the lint errors
- Run the linter: `npm run lint` or use an ESLint extension for your editor

## TODOs:
- [ ] +1
- [ ] Updated README
- [ ] Updated CHANGELOG
