### PR TITLE
Remove `linebreak-style` Rule for ES6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## To Be Released
+- Remove `linebreak-style` blocks windows users from linting their code properly [#169](https://github.com/mobify/mobify-code-style/pull/169)
 - Add in Responsive Best Practices section, updated references to Adaptive [#165](https://github.com/mobify/mobify-code-style/pull/165)
 
 ## v2.8.4 (October 31, 2017)

--- a/docs/test/good.expected.md
+++ b/docs/test/good.expected.md
@@ -4,13 +4,13 @@ Used to test style.
 
 ## GOOD: One level step down headings.
 
-<!--lint disable no-duplicate-headings-in-section -->
+<!--lint disable no-duplicate-headings-in-section-->
 
 ### GOOD: Repeated Content when rule is disabled
 
 ### GOOD: Repeated Content when rule is disabled
 
-<!--lint enable no-duplicate-headings-in-section -->
+<!--lint enable no-duplicate-headings-in-section-->
 
 ## GOOD: Section with subsections that duplicate
 

--- a/docs/test/good.md
+++ b/docs/test/good.md
@@ -4,13 +4,13 @@ Used to test style.
 
 ## GOOD: One level step down headings.
 
-<!--lint disable no-duplicate-headings-in-section -->
+<!--lint disable no-duplicate-headings-in-section-->
 
 ### GOOD: Repeated Content when rule is disabled
 
 ### GOOD: Repeated Content when rule is disabled
 
-<!--lint enable no-duplicate-headings-in-section -->
+<!--lint enable no-duplicate-headings-in-section-->
 
 ## GOOD: Section with subsections that duplicate
 

--- a/docs/test/test.sh
+++ b/docs/test/test.sh
@@ -23,7 +23,7 @@ echo "Testing bad.md ..."
 diff <("$LINT_MD" "$TEST_DIR/bad.md" --no-color 2>&1) "$TEST_DIR/bad.expected.md"
 EXIT_BAD=$?
 
-echo "Testing a-bad-filename.expected.md ..."
+echo "Testing a-bad-filename.md ..."
 diff <("$LINT_MD" "$TEST_DIR/a-bad-filename.md" --no-color 2>&1) "$TEST_DIR/a-bad-filename.expected.md"
 EXIT_BAD_FILENAME=$?
 

--- a/es6/mobify-es6.yml
+++ b/es6/mobify-es6.yml
@@ -148,9 +148,6 @@ rules:
   jsx-quotes: error
   key-spacing: error
   keyword-spacing: error
-  linebreak-style:
-    - error
-    - unix
   max-depth:
     - error
     - max: 5


### PR DESCRIPTION
Some developers have reported issues with their linter reporting errors for line endings. This is because we have our style set to `unix`. This works fine with unix obviously and macos, but it doens't play well with windows users unless they make changes to their IDE settings. Getting them to make those changes is probably more hassle than it's worth. So we have decided to remove this rule.

We are going to make this change in conjunction with adding a gitattributes file to our scaffold to allow autoconvertion for the file line endings as recommended [here](https://eslint.org/docs/rules/linebreak-style#using-this-rule-with-version-control-systems)

Linked PRs: (387)[https://github.com/mobify/mobify-platform-sdks/pull/387]
Ticket: [WEB-2316](https://mobify.atlassian.net/browse/WEB-2316)

## Changes
- remove line-break style rule

## How To Test
- (necessary config changes)
- (necessary corresponding PRs)
- (how to access the new / changed functionality -- fixtures, URLs)

## Applicable Research Resources
- (links, optional)

## TODOs:
- [ ] +1
- [ ] Updated README
- [x] Updated CHANGELOG
- [ ] (Other applicable TODOs)
