### PR TITLE
Fix CHANGELOG Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## To Be Released
+## To be released
 - Remove `linebreak-style` blocks windows users from linting their code properly [#169](https://github.com/mobify/mobify-code-style/pull/169)
 - Add in Responsive Best Practices section, updated references to Adaptive [#165](https://github.com/mobify/mobify-code-style/pull/165)
 


### PR DESCRIPTION
Mobitron automated releases are failing because of the case on the "To be release" section.

Linked PRs: (links to corresponding PRs, optional)

## Changes
- (changes here)

## How To Test
- (necessary config changes)
- (necessary corresponding PRs)
- (how to access the new / changed functionality -- fixtures, URLs)

## Applicable Research Resources
- (links, optional)

## TODOs:
- [ ] +1
- [ ] Updated README
- [ ] Updated CHANGELOG
- [ ] (Other applicable TODOs)
